### PR TITLE
Change default remote_sites_path to base_path()

### DIFF
--- a/config/ignition.php
+++ b/config/ignition.php
@@ -161,7 +161,7 @@ return [
     |
     */
 
-    'remote_sites_path' => env('IGNITION_REMOTE_SITES_PATH', ''),
+    'remote_sites_path' => env('IGNITION_REMOTE_SITES_PATH', base_path()),
     'local_sites_path' => env('IGNITION_LOCAL_SITES_PATH', ''),
 
     /*


### PR DESCRIPTION
As issued here https://github.com/facade/ignition/issues/314, many people have problem with `remote_sites_path` not working as expected.

I think its the `local_sites_path` that they were talking about, one problem i found is when we set `remote_sites_path` to directory other than laravel `base_path`, the `local_sites_path` just wont work. the url fallback-ted to default and `local_sites_path` never used.

One simple solution i found was changing the `remote_sites_path` to laravel `base_path` instead of empty string `''` or `null`, then only set the `local_sites_path`.

I have tested on `facade/ignition`, but not tested yet with `spatie/laravel-ignition` since i cannot install from packagist:

![image](https://user-images.githubusercontent.com/20186786/122774874-c9c51180-d2d3-11eb-89d9-74673ae3c9b3.png)

------

note: #CMIIW, i still dont really know what happened under the hood :smiley: 
