### PR TITLE
Move registering routes to boot method of IgnitionServiceProvider

### DIFF
--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -45,7 +45,6 @@ class IgnitionServiceProvider extends ServiceProvider
         $this->registerRenderer();
         $this->registerRecorders();
         $this->registerLogHandler();
-        $this->registerRoutes();
     }
 
     public function boot()
@@ -55,6 +54,7 @@ class IgnitionServiceProvider extends ServiceProvider
             $this->publishConfigs();
         }
 
+        $this->registerRoutes();
         $this->configureTinker();
         $this->configureOctane();
         $this->registerViewExceptionMapper();


### PR DESCRIPTION
According to [Laravel docs](https://laravel.com/docs/9.x/providers#writing-service-providers), registering routes should never happen within the `register` method, as only binding should happen there. In practice, this causes a problem when trying to override/extend the base Laravel `FilesystemServiceProvider`, which combined with registering this package triggers an `Illuminate\Contracts\Container\BindingResolutionException` with message `Target class [files] does not exist.`.

Therefore, moving the registering of routes to the `boot` method looks like a more robust approach to me. See also the example from the [Laravel docs on the `loadRoutesFrom` method](https://laravel.com/docs/9.x/packages#routes).