### PR TITLE
Remove duplicate composer.json requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "monolog/monolog": "^2.3",
-        "spatie/ignition": "^1.2",
         "spatie/ignition": "^1.2.4",
         "spatie/flare-client-php": "^1.0.1",
         "symfony/console": "^5.0|^6.0",


### PR DESCRIPTION
With PR #66 the requirement was added instead of modifying
I think 1.2.4 already includes the needed changes from [spatie/ignition/pull/57](https://github.com/spatie/ignition/pull/57)


![image](https://user-images.githubusercontent.com/13331388/159216637-1e194b53-276f-4d0c-94ca-1ca9b5c1d4f5.png)