### PR TITLE
Fixed reading of maximum_number_of_collected_logs

### DIFF
--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -157,7 +157,7 @@ class IgnitionServiceProvider extends ServiceProvider
         $this->app->singleton(LogRecorder::class, function (Application $app): LogRecorder {
             return new LogRecorder(
                 $app,
-                config()->get('flare.flare_middleware' . AddLogs::class . 'maximum_number_of_collected_logs')
+                config()->get('flare.flare_middleware.' . AddLogs::class . '.maximum_number_of_collected_logs')
             );
         });
 


### PR DESCRIPTION
This fixes memory leak when collecting logs, cause `maximum_number_of_collected_logs` config value was always `NULL` and collecting of logs records was infinite.