### PR TITLE
Fix solution for missing Mix manifest

### DIFF
--- a/src/Solutions/SolutionProviders/MissingMixManifestSolutionProvider.php
+++ b/src/Solutions/SolutionProviders/MissingMixManifestSolutionProvider.php
@@ -12,7 +12,7 @@ class MissingMixManifestSolutionProvider implements HasSolutionsForThrowable
 {
     public function canSolve(Throwable $throwable): bool
     {
-        return Str::startsWith($throwable->getMessage(), 'The Mix manifest does not exist');
+        return Str::startsWith($throwable->getMessage(), 'Mix manifest not found');
     }
 
     public function getSolutions(Throwable $throwable): array

--- a/tests/Solutions/MixManifestNotFoundSolutionProviderTest.php
+++ b/tests/Solutions/MixManifestNotFoundSolutionProviderTest.php
@@ -6,7 +6,7 @@ use Spatie\LaravelIgnition\Solutions\SolutionProviders\MissingMixManifestSolutio
 
 it('can solve a missing mix manifest exception', function () {
     $canSolve = app(MissingMixManifestSolutionProvider::class)
-        ->canSolve(new Exception('The Mix manifest does not exist.'));
+        ->canSolve(new Exception('Mix manifest not found.'));
 
     expect($canSolve)->toBeTrue();
 });
@@ -14,7 +14,7 @@ it('can solve a missing mix manifest exception', function () {
 it('can recommend running npm install and npm run dev', function () {
     /** @var \Spatie\Ignition\Contracts\Solution $solution */
     $solution = app(MissingMixManifestSolutionProvider::class)
-        ->getSolutions(new Exception('The Mix manifest does not exist.'))[0];
+        ->getSolutions(new Exception('Mix manifest not found.'))[0];
 
     expect(Str::contains($solution->getSolutionDescription(), 'Did you forget to run `npm ci && npm run dev`?'))->toBeTrue();
 });

--- a/tests/Solutions/MixManifestNotFoundSolutionProviderTest.php
+++ b/tests/Solutions/MixManifestNotFoundSolutionProviderTest.php
@@ -16,5 +16,5 @@ it('can recommend running npm install and npm run dev', function () {
     $solution = app(MissingMixManifestSolutionProvider::class)
         ->getSolutions(new Exception('Mix manifest not found.'))[0];
 
-    expect(Str::contains($solution->getSolutionDescription(), 'Did you forget to run `npm ci && npm run dev`?'))->toBeTrue();
+    expect(Str::contains($solution->getSolutionDescription(), 'Did you forget to run `npm install && npm run dev`?'))->toBeTrue();
 });


### PR DESCRIPTION
This PR fixes the solution for a missing Mix manifest.

The exception message changed slightly a few months ago https://github.com/laravel/framework/pull/42082