### PR TITLE
Add solution for missing Vite manifest

### DIFF
--- a/src/Solutions/SolutionProviders/MissingViteManifestSolutionProvider.php
+++ b/src/Solutions/SolutionProviders/MissingViteManifestSolutionProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\LaravelIgnition\Solutions\SolutionProviders;
+
+use Illuminate\Support\Str;
+use Spatie\Ignition\Contracts\BaseSolution;
+use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
+use Throwable;
+
+class MissingViteManifestSolutionProvider implements HasSolutionsForThrowable
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        return Str::startsWith($throwable->getMessage(), 'Vite manifest not found');
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [
+            BaseSolution::create('Missing Vite Manifest File')
+                ->setSolutionDescription('Did you forget to run `npm install && npm run dev`?'),
+        ];
+    }
+}

--- a/tests/Solutions/ViteManifestNotFoundSolutionProviderTest.php
+++ b/tests/Solutions/ViteManifestNotFoundSolutionProviderTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Str;
+use Spatie\LaravelIgnition\Solutions\SolutionProviders\MissingViteManifestSolutionProvider;
+
+it('can solve a missing Vite manifest exception', function () {
+    $canSolve = app(MissingViteManifestSolutionProvider::class)
+        ->canSolve(new Exception('Vite manifest not found at: public/build/manifest.json'));
+
+    expect($canSolve)->toBeTrue();
+});
+
+it('can recommend running npm install and npm run dev', function () {
+    /** @var \Spatie\Ignition\Contracts\Solution $solution */
+    $solution = app(MissingViteManifestSolutionProvider::class)
+        ->getSolutions(new Exception('Vite manifest not found at: public/build/manifest.json'))[0];
+
+    expect(Str::contains($solution->getSolutionDescription(), 'Did you forget to run `npm install && npm run dev`?'))->toBeTrue();
+});


### PR DESCRIPTION
This PR adds a new solution for Laravel's upcoming first-party Vite integration: https://github.com/laravel/framework/pull/42785

We'll be merging in the next few days so it would be cool to have this already in place, but I understand if you'd prefer to wait for the tagged release.