### PR TITLE
Add vitejs autorefresh to error page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "monolog/monolog": "^2.3",
-        "spatie/ignition": "^1.2.4",
+        "spatie/ignition": "^1.4.1",
         "spatie/flare-client-php": "^1.0.1",
         "symfony/console": "^5.0|^6.0",
         "symfony/var-dumper": "^5.0|^6.0",

--- a/src/Renderers/ErrorPageRenderer.php
+++ b/src/Renderers/ErrorPageRenderer.php
@@ -15,6 +15,21 @@ class ErrorPageRenderer
 {
     public function render(Throwable $throwable): void
     {
+        $vitejsAutoRefresh = '';
+
+        if (class_exists('Illuminate\Foundation\Vite')) {
+
+            $vite = app(\Illuminate\Foundation\Vite::class);
+
+            $hotFile = method_exists($vite, 'hotFile')
+                             ? $vite->hotFile()
+                             : public_path('/hot');
+
+            if (is_file($hotFile)) {
+                $vitejsAutoRefresh = $vite->__invoke([]);
+            }
+        }
+
         app(Ignition::class)
             ->resolveDocumentationLink(
                 fn (Throwable $throwable) => (new LaravelDocumentationLinkFinder())->findLinkForThrowable($throwable)
@@ -25,6 +40,7 @@ class ErrorPageRenderer
             ->setContextProviderDetector(new LaravelContextProviderDetector())
             ->setSolutionTransformerClass(LaravelSolutionTransformer::class)
             ->applicationPath(base_path())
+            ->addCustomHtmlToHead($vitejsAutoRefresh)
             ->renderException($throwable);
     }
 }


### PR DESCRIPTION
Hey!

I often encounter the Problem while developing that I run into an error and then I need to manually reload the page after correcting the error. Using ViteJS it is already possible to reload the page automatically on file save and I would love it, if there is a way for auto reloading the error page to check if the code is running correctly.

For that I added the ability to add custom HTML to the error page in https://github.com/spatie/ignition/pull/161

This PR is a follow up for adding the ViteJS script for reloading the page to the error page.

Originally discussed in https://github.com/spatie/ignition/pull/155

> **Warning**  
> Blocked by a PR to `laravel/framework` so that the method `hotFile` is `public` instead of `protected`
> I will link to it after I created the PR