### PR TITLE
fix memory leak in production environments

### DIFF
--- a/config/ignition.php
+++ b/config/ignition.php
@@ -216,7 +216,7 @@ return [
         env('APP_DEBUG', true) && env('APP_ENV', 'local') != 'production'
     ),
     
-    'recordings' => [
+    'recorders' => [
         'jobs' => env('IGNITION_RECORD_JOBS', true),
         'dumps' => env('IGNITION_RECORD_DUMPS', true),
         'logs' => env('IGNITION_RECORD_LOGS', true),

--- a/config/ignition.php
+++ b/config/ignition.php
@@ -211,4 +211,16 @@ return [
 
     'settings_file_path' => '',
 
+    'should_record' => env(
+        'IGNITION_RECORD',
+        env('APP_ENV', 'local') != 'production' && env('APP_DEBUG', true)
+    ),
+    
+    'recordings' => [
+        'jobs' => env('IGNITION_RECORD_JOBS', true),
+        'dumps' => env('IGNITION_RECORD_DUMPS', true),
+        'logs' => env('IGNITION_RECORD_LOGS', true),
+        'queries' => env('IGNITION_RECORD_QUERIES', true)
+    ]
+
 ];

--- a/config/ignition.php
+++ b/config/ignition.php
@@ -213,7 +213,7 @@ return [
 
     'should_record' => env(
         'IGNITION_RECORD',
-        env('APP_ENV', 'local') != 'production' && env('APP_DEBUG', true)
+        env('APP_DEBUG', true) && env('APP_ENV', 'local') != 'production'
     ),
     
     'recordings' => [

--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -244,15 +244,23 @@ class IgnitionServiceProvider extends ServiceProvider
 
     protected function startRecorders(): void
     {
-        // TODO: Ignition feature toggles
-
-        $this->app->make(DumpRecorder::class)->start();
-
-        $this->app->make(LogRecorder::class)->start();
-
-        $this->app->make(QueryRecorder::class)->start();
-
-        $this->app->make(JobRecorder::class)->start();
+        if($this->app->config['ignition.should_record']) {
+            if($this->app->config['ignition.record_dumps']) { 
+                $this->app->make(DumpRecorder::class)->start();
+            }
+    
+            if($this->app->config['ignition.record_logs']) { 
+                $this->app->make(LogRecorder::class)->start();
+            }
+    
+            if($this->app->config['ignition.record_queries']) { 
+                $this->app->make(QueryRecorder::class)->start();
+            }
+    
+            if($this->app->config['ignition.record_jobs']) { 
+                $this->app->make(JobRecorder::class)->start();
+            }
+        }
     }
 
     protected function configureQueue(): void


### PR DESCRIPTION
Currently, this causes a memory leak in production environments even when the application debug is turned off and ignition is unavailable this resolve this by disabling recording in production environments. this may be a little too strong of a rule but I can alter it not to have the master kill switch. 

this also adds the ability to to turn off recorders individually.

Thanks. 