### PR TITLE
fix memory leak in production environments;

### DIFF
--- a/config/ignition.php
+++ b/config/ignition.php
@@ -211,4 +211,16 @@ return [
 
     'settings_file_path' => '',
 
+    'should_record' => env(
+        'IGNITION_RECORD',
+        env('APP_DEBUG', true) && env('APP_ENV', 'local') != 'production'
+    ),
+    
+    'recorders' => [
+        'jobs' => env('IGNITION_RECORD_JOBS', true),
+        'dumps' => env('IGNITION_RECORD_DUMPS', true),
+        'logs' => env('IGNITION_RECORD_LOGS', true),
+        'queries' => env('IGNITION_RECORD_QUERIES', true)
+    ]
+
 ];

--- a/config/ignition.php
+++ b/config/ignition.php
@@ -3,6 +3,10 @@
 use Spatie\Ignition\Solutions\SolutionProviders\BadMethodCallSolutionProvider;
 use Spatie\Ignition\Solutions\SolutionProviders\MergeConflictSolutionProvider;
 use Spatie\Ignition\Solutions\SolutionProviders\UndefinedPropertySolutionProvider;
+use Spatie\LaravelIgnition\Recorders\DumpRecorder\DumpRecorder;
+use Spatie\LaravelIgnition\Recorders\JobRecorder\JobRecorder;
+use Spatie\LaravelIgnition\Recorders\LogRecorder\LogRecorder;
+use Spatie\LaravelIgnition\Recorders\QueryRecorder\QueryRecorder;
 use Spatie\LaravelIgnition\Solutions\SolutionProviders\DefaultDbNameSolutionProvider;
 use Spatie\LaravelIgnition\Solutions\SolutionProviders\GenericLaravelExceptionSolutionProvider;
 use Spatie\LaravelIgnition\Solutions\SolutionProviders\IncorrectValetDbCredentialsSolutionProvider;
@@ -211,16 +215,20 @@ return [
 
     'settings_file_path' => '',
 
-    'should_record' => env(
-        'IGNITION_RECORD',
-        env('APP_DEBUG', true) && env('APP_ENV', 'local') != 'production'
-    ),
-    
-    'recorders' => [
-        'jobs' => env('IGNITION_RECORD_JOBS', true),
-        'dumps' => env('IGNITION_RECORD_DUMPS', true),
-        'logs' => env('IGNITION_RECORD_LOGS', true),
-        'queries' => env('IGNITION_RECORD_QUERIES', true)
-    ]
+    /*
+    |--------------------------------------------------------------------------
+    | Recorders
+    |--------------------------------------------------------------------------
+    |
+    | Ignition registers a couple of recorders when it is enabled. Below you may
+    | specify a recorders will be used to record specific events.
+    |
+    */
 
+    'recorders' => [
+        DumpRecorder::class,
+        JobRecorder::class,
+        LogRecorder::class,
+        QueryRecorder::class
+    ]
 ];

--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -244,15 +244,24 @@ class IgnitionServiceProvider extends ServiceProvider
 
     protected function startRecorders(): void
     {
-        // TODO: Ignition feature toggles
-
-        $this->app->make(DumpRecorder::class)->start();
-
-        $this->app->make(LogRecorder::class)->start();
-
-        $this->app->make(QueryRecorder::class)->start();
-
-        $this->app->make(JobRecorder::class)->start();
+        if ($this->app->config['ignition.should_record']) {
+            
+            if ($this->app->config['ignition.recorders.dumps']) { 
+                $this->app->make(DumpRecorder::class)->start();
+            }
+    
+            if ($this->app->config['ignition.recorders.logs']) { 
+                $this->app->make(LogRecorder::class)->start();
+            }
+    
+            if ($this->app->config['ignition.recorders.queries']) { 
+                $this->app->make(QueryRecorder::class)->start();
+            }
+    
+            if ($this->app->config['ignition.recorders.jobs']) { 
+                $this->app->make(JobRecorder::class)->start();
+            }
+        }
     }
 
     protected function configureQueue(): void

--- a/src/IgnitionServiceProvider.php
+++ b/src/IgnitionServiceProvider.php
@@ -244,23 +244,8 @@ class IgnitionServiceProvider extends ServiceProvider
 
     protected function startRecorders(): void
     {
-        if ($this->app->config['ignition.should_record']) {
-            
-            if ($this->app->config['ignition.recorders.dumps']) { 
-                $this->app->make(DumpRecorder::class)->start();
-            }
-    
-            if ($this->app->config['ignition.recorders.logs']) { 
-                $this->app->make(LogRecorder::class)->start();
-            }
-    
-            if ($this->app->config['ignition.recorders.queries']) { 
-                $this->app->make(QueryRecorder::class)->start();
-            }
-    
-            if ($this->app->config['ignition.recorders.jobs']) { 
-                $this->app->make(JobRecorder::class)->start();
-            }
+        foreach ($this->app->config['ignition.recorders'] as $recorder) {
+            $this->app->make($recorder)->start();
         }
     }
 


### PR DESCRIPTION
Currently, ignition logs information even when the APP_DEBUG is set to false this uses quite a bit of memory in production environments and can kill jobs that are doing bulk inserts in a look. I've added some logic and additional variables to determine when and when not to log in based on the environment and the APP_DEBUG var. I've also added the ability to turn off individual recorders. 

Ive yet to add a unit test cause I'm not sure if yall will accept this implementation. if this is fine ill go ahead and write the testing for it. 