### PR TITLE
Update run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,9 +13,6 @@ jobs:
                 laravel: [10.*]
                 stability: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
-                exclude:
-                   - laravel: 10.*
-                     php: 8.0
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 


### PR DESCRIPTION
PHP 8.0 isn't part of the matrix. That means that the exlcude for PHP 8.0 with Laravel 10 can be removed.