### PR TITLE
Help Sail users when they forget to run an Artisan command using `sail`

### DIFF
--- a/config/ignition.php
+++ b/config/ignition.php
@@ -23,6 +23,7 @@ use Spatie\LaravelIgnition\Solutions\SolutionProviders\UndefinedViewVariableSolu
 use Spatie\LaravelIgnition\Solutions\SolutionProviders\UnknownValidationSolutionProvider;
 use Spatie\LaravelIgnition\Solutions\SolutionProviders\ViewNotFoundSolutionProvider;
 use Spatie\LaravelIgnition\Solutions\SolutionProviders\OpenAiSolutionProvider;
+use Spatie\LaravelIgnition\Solutions\SolutionProviders\SailNetworkSolutionProvider;
 
 return [
 
@@ -117,6 +118,7 @@ return [
         UndefinedViewVariableSolutionProvider::class,
         GenericLaravelExceptionSolutionProvider::class,
         OpenAiSolutionProvider::class,
+        SailNetworkSolutionProvider::class,
     ],
 
     /*

--- a/src/Solutions/SolutionProviders/SailNetworkSolutionProvider.php
+++ b/src/Solutions/SolutionProviders/SailNetworkSolutionProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\LaravelIgnition\Solutions\SolutionProviders;
+
+use Spatie\Ignition\Contracts\BaseSolution;
+use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
+use Throwable;
+
+class SailNetworkSolutionProvider implements HasSolutionsForThrowable
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        return app()->runningInConsole()
+            && str_contains($throwable->getMessage(), 'php_network_getaddresses')
+            && file_exists(base_path('vendor/bin/sail'))
+            && file_exists(base_path('docker-compose.yml'))
+            && env('LARAVEL_SAIL') === null;
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [
+            BaseSolution::create('Network address not found')
+                ->setSolutionDescription('Did you mean to use `sail artisan`?')
+                ->setDocumentationLinks([
+                    'Sail: Executing Artisan Commands' => 'https://laravel.com/docs/sail#executing-artisan-commands',
+                ]),
+        ];
+    }
+}


### PR DESCRIPTION
This PR is intended to help Sail users when they forget to run an Artisan command using `sail` and it fails due to not being able to resolve a network address.

![image](https://github.com/spatie/laravel-ignition/assets/4977161/a8eba7ce-c085-48ee-9831-aae1d91bbbce)
