### PR TITLE
[2.x] Adds L11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,9 @@ jobs:
                 livewire: [2, 3]
                 stability: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
+                exclude:
+                  - php: 8.1
+                    laravel: 11.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - LW${{ matrix.livewire }} -${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
             -  name: Install dependencies
                run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.62.1" --no-interaction --no-update
+                    composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.72.1" --no-interaction --no-update
                     composer update --with="livewire/livewire:^${{ matrix.livewire }}" --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
 
             - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,12 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.1, 8.2, 8.3]
-                laravel: [10.*]
+                laravel: [10.*, 11.*]
+                livewire: [2, 3]
                 stability: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - LW${{ matrix.livewire }} -${{ matrix.stability }} - ${{ matrix.os }}
 
         steps:
             - name: Checkout code
@@ -42,8 +43,7 @@ jobs:
             -  name: Install dependencies
                run: |
                     composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.62.1" --no-interaction --no-update
-                    composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
+                    composer update --with="livewire/livewire:^${{ matrix.livewire }}" --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
 
             - name: Execute tests
               run: vendor/bin/pest
-

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
                     laravel: 11.*
                 exclude:
                   - laravel: 11.*
-                  - livewire: 2.11
+                    livewire: 2.11
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - LW${{ matrix.livewire }} -${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,6 @@ jobs:
                 exclude:
                   - php: 8.1
                     laravel: 11.*
-                exclude:
                   - laravel: 11.*
                     livewire: 2.11
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
             matrix:
                 php: [8.1, 8.2, 8.3]
                 laravel: [10.*, 11.*]
-                livewire: [2.*, 3.*]
+                livewire: [2.11, 3.0]
                 stability: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
                 exclude:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,9 @@ jobs:
                 exclude:
                   - php: 8.1
                     laravel: 11.*
+                exclude:
+                  - laravel: 11.*
+                  - livewire: 2.11
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - LW${{ matrix.livewire }} -${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
             matrix:
                 php: [8.1, 8.2, 8.3]
                 laravel: [10.*, 11.*]
-                livewire: [2.11, 3.0]
+                livewire: [2.11, 3.3.5]
                 stability: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
                 exclude:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
             matrix:
                 php: [8.1, 8.2, 8.3]
                 laravel: [10.*, 11.*]
-                livewire: [2, 3]
+                livewire: [2.*, 3.*]
                 stability: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest]
                 exclude:

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "symfony/var-dumper": "^6.2.3|^7.0"
     },
     "require-dev": {
-        "livewire/livewire": "^2.11|dev-feat/l11",
+        "livewire/livewire": "^2.11|^3.0|dev-feat/l11",
         "mockery/mockery": "^1.5.1",
-        "openai-php/client": "^0.7.3",
+        "openai-php/client": "^0.8.0",
         "orchestra/testbench": "^8.0|^9.0",
         "pestphp/pest": "^1.22.3|^2.0",
         "phpstan/extension-installer": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -21,18 +21,18 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "illuminate/support": "^10.0",
+        "illuminate/support": "^10.0|^11.0",
         "spatie/flare-client-php": "^1.3.5",
         "spatie/ignition": "^1.9",
-        "symfony/console": "^6.2.3",
-        "symfony/var-dumper": "^6.2.3"
+        "symfony/console": "^6.2.3|^7.0",
+        "symfony/var-dumper": "^6.2.3|^7.0"
     },
     "require-dev": {
-        "livewire/livewire": "^2.11",
+        "livewire/livewire": "^2.11|dev-feat/l11",
         "mockery/mockery": "^1.5.1",
-        "openai-php/client": "^0.3.4",
-        "orchestra/testbench": "^8.0",
-        "pestphp/pest": "^1.22.3",
+        "openai-php/client": "^0.7.3",
+        "orchestra/testbench": "^8.0|^9.0",
+        "pestphp/pest": "^1.22.3|^2.0",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan-deprecation-rules": "^1.1.1",
         "phpstan/phpstan-phpunit": "^1.3.3",
@@ -46,7 +46,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "phpstan/extension-installer": true,
-            "pestphp/pest-plugin": true
+            "pestphp/pest-plugin": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
         "symfony/var-dumper": "^6.2.3|^7.0"
     },
     "require-dev": {
-        "livewire/livewire": "^2.11|^3.0|dev-feat/l11",
+        "livewire/livewire": "^2.11|^3.0",
         "mockery/mockery": "^1.5.1",
         "openai-php/client": "^0.8.0",
         "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^1.22.3|^2.0",
+        "pestphp/pest": "^2.0",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan-deprecation-rules": "^1.1.1",
         "phpstan/phpstan-phpunit": "^1.3.3",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "livewire/livewire": "^2.11|^3.0",
         "mockery/mockery": "^1.5.1",
-        "openai-php/client": "^0.8.0",
+        "openai-php/client": "^0.8.1",
         "orchestra/testbench": "^8.0|^9.0",
         "pestphp/pest": "^2.30",
         "phpstan/extension-installer": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "mockery/mockery": "^1.5.1",
         "openai-php/client": "^0.8.0",
         "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^2.0",
+        "pestphp/pest": "^2.30",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan-deprecation-rules": "^1.1.1",
         "phpstan/phpstan-phpunit": "^1.3.3",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/var-dumper": "^6.2.3|^7.0"
     },
     "require-dev": {
-        "livewire/livewire": "^2.11|^3.0",
+        "livewire/livewire": "^2.11|^3.3.5",
         "mockery/mockery": "^1.5.1",
         "openai-php/client": "^0.8.1",
         "orchestra/testbench": "^8.0|^9.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <testsuites>
-    <testsuite name="Flare Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+    backupGlobals="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    executionOrder="random"
+    failOnWarning="true"
+    failOnRisky="true"
+    failOnEmptyTestSuite="true"
+    beStrictAboutOutputDuringTests="true"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
+>
+    <testsuites>
+        <testsuite name="Laravel Ignition Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/ContextProviders/LaravelLivewireRequestContextProviderTest.php
+++ b/tests/ContextProviders/LaravelLivewireRequestContextProviderTest.php
@@ -7,7 +7,7 @@ use Spatie\LaravelIgnition\Tests\TestClasses\FakeLivewireManager;
 
 beforeEach(function () {
     $this->livewireManager = FakeLivewireManager::setUp();
-});
+})->skip(LIVEWIRE_VERSION_3, 'Missing Livewire 3 support.');
 
 it('returns the referer url and method', function () {
     $context = createRequestContext([

--- a/tests/ContextProviders/LaravelLivewireRequestContextProviderTest.php
+++ b/tests/ContextProviders/LaravelLivewireRequestContextProviderTest.php
@@ -166,7 +166,7 @@ function createRequestContext(array $fingerprint, array $updates = [], array $se
         'fingerprint' => $fingerprint,
         'serverMemo' => $serverMemo,
         'updates' => $updates,
-    ]);
+    ], ['X-Livewire' => 1]);
 
     return new LaravelLivewireRequestContextProvider($providedRequest, test()->livewireManager);
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,7 +1,10 @@
 <?php
 
 use Dotenv\Dotenv;
+use Livewire\Mechanisms\ComponentRegistry;
 use Spatie\LaravelIgnition\Tests\TestCase;
+
+define('LIVEWIRE_VERSION_3', class_exists(ComponentRegistry::class));
 
 uses(TestCase::class)->in(__DIR__);
 

--- a/tests/Solutions/SolutionProviders/UndefinedLivewireMethodSolutionProviderTest.php
+++ b/tests/Solutions/SolutionProviders/UndefinedLivewireMethodSolutionProviderTest.php
@@ -17,4 +17,4 @@ it('can solve an unknown livewire method', function () {
 
     expect($solution->getSolutionTitle())->toBe('Possible typo `Spatie\LaravelIgnition\Tests\stubs\Components\TestLivewireComponent::chnge`');
     expect($solution->getSolutionDescription())->toBe('Did you mean `Spatie\LaravelIgnition\Tests\stubs\Components\TestLivewireComponent::change`?');
-});
+})->skip(LIVEWIRE_VERSION_3, 'Missing Livewire 3 support.');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function setUp(): void
     {
-        ray()->newScreen($this->getName());
+        // ray()->newScreen($this->getName());
 
         parent::setUp();
     }


### PR DESCRIPTION
Livewire 3 support for Laravel 11 has been merged and tagged, so we can now move forward with this.

This pull request adds L11 support to this package. Note that I've noticed Ignition does not support Livewire 3. While this is not related to this pull request, I've already adjusted the CI to run tests against Livewire 3, and failing tests are being skipped with the message 'Missing Livewire 3 support.'"