### PR TITLE
Add unknown collations for MySQL 8 and MariaDB

### DIFF
--- a/config/ignition.php
+++ b/config/ignition.php
@@ -24,6 +24,8 @@ use Spatie\LaravelIgnition\Solutions\SolutionProviders\UnknownValidationSolution
 use Spatie\LaravelIgnition\Solutions\SolutionProviders\ViewNotFoundSolutionProvider;
 use Spatie\LaravelIgnition\Solutions\SolutionProviders\OpenAiSolutionProvider;
 use Spatie\LaravelIgnition\Solutions\SolutionProviders\SailNetworkSolutionProvider;
+use Spatie\LaravelIgnition\Solutions\SolutionProviders\UnknownMariadbCollationSolutionProvider;
+use Spatie\LaravelIgnition\Solutions\SolutionProviders\UnknownMysql8CollationSolutionProvider;
 
 return [
 
@@ -119,6 +121,8 @@ return [
         GenericLaravelExceptionSolutionProvider::class,
         OpenAiSolutionProvider::class,
         SailNetworkSolutionProvider::class,
+        UnknownMysql8CollationSolutionProvider::class,
+        UnknownMariadbCollationSolutionProvider::class,
     ],
 
     /*

--- a/src/Solutions/SolutionProviders/UnknownMariadbCollationSolutionProvider.php
+++ b/src/Solutions/SolutionProviders/UnknownMariadbCollationSolutionProvider.php
@@ -4,9 +4,7 @@ namespace Spatie\LaravelIgnition\Solutions\SolutionProviders;
 
 use Illuminate\Database\QueryException;
 use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
-use Spatie\LaravelIgnition\Solutions\SuggestUsingCorrectDbNameSolution;
 use Spatie\LaravelIgnition\Solutions\SuggestUsingMariadbDatabaseSolution;
-use Spatie\LaravelIgnition\Solutions\SuggestUsingMysql8DatabaseSolution;
 use Throwable;
 
 class UnknownMariadbCollationSolutionProvider implements HasSolutionsForThrowable

--- a/src/Solutions/SolutionProviders/UnknownMariadbCollationSolutionProvider.php
+++ b/src/Solutions/SolutionProviders/UnknownMariadbCollationSolutionProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spatie\LaravelIgnition\Solutions\SolutionProviders;
+
+use Illuminate\Database\QueryException;
+use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
+use Spatie\LaravelIgnition\Solutions\SuggestUsingCorrectDbNameSolution;
+use Spatie\LaravelIgnition\Solutions\SuggestUsingMariadbDatabaseSolution;
+use Spatie\LaravelIgnition\Solutions\SuggestUsingMysql8DatabaseSolution;
+use Throwable;
+
+class UnknownMariadbCollationSolutionProvider implements HasSolutionsForThrowable
+{
+    const MYSQL_UNKNOWN_COLLATION_CODE = 1273;
+
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof QueryException) {
+            return false;
+        }
+
+        if ($throwable->getCode() !== self::MYSQL_UNKNOWN_COLLATION_CODE) {
+            return false;
+        }
+
+        return str_contains(
+            $throwable->getMessage(),
+            'Unknown collation: \'utf8mb4_uca1400_ai_ci\''
+        );
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [new SuggestUsingMariadbDatabaseSolution()];
+    }
+}

--- a/src/Solutions/SolutionProviders/UnknownMysql8CollationSolutionProvider.php
+++ b/src/Solutions/SolutionProviders/UnknownMysql8CollationSolutionProvider.php
@@ -4,7 +4,6 @@ namespace Spatie\LaravelIgnition\Solutions\SolutionProviders;
 
 use Illuminate\Database\QueryException;
 use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
-use Spatie\LaravelIgnition\Solutions\SuggestUsingCorrectDbNameSolution;
 use Spatie\LaravelIgnition\Solutions\SuggestUsingMysql8DatabaseSolution;
 use Throwable;
 

--- a/src/Solutions/SolutionProviders/UnknownMysql8CollationSolutionProvider.php
+++ b/src/Solutions/SolutionProviders/UnknownMysql8CollationSolutionProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\LaravelIgnition\Solutions\SolutionProviders;
+
+use Illuminate\Database\QueryException;
+use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
+use Spatie\LaravelIgnition\Solutions\SuggestUsingCorrectDbNameSolution;
+use Spatie\LaravelIgnition\Solutions\SuggestUsingMysql8DatabaseSolution;
+use Throwable;
+
+class UnknownMysql8CollationSolutionProvider implements HasSolutionsForThrowable
+{
+    const MYSQL_UNKNOWN_COLLATION_CODE = 1273;
+
+    public function canSolve(Throwable $throwable): bool
+    {
+        if (! $throwable instanceof QueryException) {
+            return false;
+        }
+
+        if ($throwable->getCode() !== self::MYSQL_UNKNOWN_COLLATION_CODE) {
+            return false;
+        }
+
+        return str_contains(
+            $throwable->getMessage(),
+            'Unknown collation: \'utf8mb4_0900_ai_ci\''
+        );
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [new SuggestUsingMysql8DatabaseSolution()];
+    }
+}

--- a/src/Solutions/SuggestUsingMariadbDatabaseSolution.php
+++ b/src/Solutions/SuggestUsingMariadbDatabaseSolution.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\LaravelIgnition\Solutions;
+
+use Spatie\Ignition\Contracts\Solution;
+
+class SuggestUsingMariadbDatabaseSolution implements Solution
+{
+    public function getSolutionTitle(): string
+    {
+        return 'Database is not a MariaDB database';
+    }
+
+    public function getSolutionDescription(): string
+    {
+        return "Laravel 11 changed the default collation for MySQL and MariaDB. It seems you are trying to use the MariaDB collation `utf8mb4_uca1400_ai_ci` with a MySQL database.\n\nEdit the `.env` file and use the correct database in the `DB_CONNECTION` key.";
+    }
+
+    /** @return array<string, string> */
+    public function getDocumentationLinks(): array
+    {
+        return [
+            'Database: Getting Started docs' => 'https://laravel.com/docs/master/database#configuration',
+        ];
+    }
+}

--- a/src/Solutions/SuggestUsingMysql8DatabaseSolution.php
+++ b/src/Solutions/SuggestUsingMysql8DatabaseSolution.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\LaravelIgnition\Solutions;
+
+use Spatie\Ignition\Contracts\Solution;
+
+class SuggestUsingMysql8DatabaseSolution implements Solution
+{
+    public function getSolutionTitle(): string
+    {
+        return 'Database is not a MySQL 8 database';
+    }
+
+    public function getSolutionDescription(): string
+    {
+        return "Laravel 11 changed the default collation for MySQL and MariaDB. It seems you are trying to use the MySQL 8 collation `utf8mb4_0900_ai_ci` with a MariaDB or MySQL 5.7 database.\n\nEdit the `.env` file and use the correct database in the `DB_CONNECTION` key.";
+    }
+
+    /** @return array<string, string> */
+    public function getDocumentationLinks(): array
+    {
+        return [
+            'Database: Getting Started docs' => 'https://laravel.com/docs/master/database#configuration',
+        ];
+    }
+}

--- a/tests/Solutions/SolutionProviders/UnknownMariadbCollationSolutionProviderTest.php
+++ b/tests/Solutions/SolutionProviders/UnknownMariadbCollationSolutionProviderTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\QueryException;
+use Spatie\LaravelIgnition\Solutions\SolutionProviders\UnknownMariadbCollationSolutionProvider;
+
+it('can solve an an unknown mariadb collation ', function () {
+    $solutionProvider = new UnknownMariadbCollationSolutionProvider();
+
+    $exception = new QueryException(
+        'mysql',
+        'select table_name as `name`, (data_length + index_length) as `size`, table_comment as `comment`, engine as `engine`, table_collation as `collation` from information_schema.tables where table_schema = \'mariadb_test\' and table_type = \'BASE TABLE\' order by table_name',
+        [],
+        new Exception('SQLSTATE[HY000]: General error: 1273 Unknown collation: \'utf8mb4_uca1400_ai_ci\'')
+    );
+
+    $solutions = $solutionProvider->getSolutions($exception);
+
+    $solution = $solutions[0];
+
+    expect($solution->getSolutionDescription())->toBe("Laravel 11 changed the default collation for MySQL and MariaDB. It seems you are trying to use the MariaDB collation `utf8mb4_uca1400_ai_ci` with a MySQL database.\n\nEdit the `.env` file and use the correct database in the `DB_CONNECTION` key.");
+});

--- a/tests/Solutions/SolutionProviders/UnknownMysql8CollationSolutionProviderTest.php
+++ b/tests/Solutions/SolutionProviders/UnknownMysql8CollationSolutionProviderTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\QueryException;
+use Spatie\LaravelIgnition\Solutions\SolutionProviders\UnknownMysql8CollationSolutionProvider;
+
+it('can solve an an unknown mysql collation ', function () {
+    $solutionProvider = new UnknownMysql8CollationSolutionProvider();
+
+    $exception = new QueryException(
+        'mariadb',
+        'select table_name as `name`, (data_length + index_length) as `size`, table_comment as `comment`, engine as `engine`, table_collation as `collation` from information_schema.tables where table_schema = \'mariadb_test\' and table_type = \'BASE TABLE\' order by table_name',
+        [],
+        new Exception('SQLSTATE[HY000]: General error: 1273 Unknown collation: \'utf8mb4_0900_ai_ci\'')
+    );
+
+    $solutions = $solutionProvider->getSolutions($exception);
+
+    $solution = $solutions[0];
+
+    expect($solution->getSolutionDescription())->toBe("Laravel 11 changed the default collation for MySQL and MariaDB. It seems you are trying to use the MySQL 8 collation `utf8mb4_0900_ai_ci` with a MariaDB or MySQL 5.7 database.\n\nEdit the `.env` file and use the correct database in the `DB_CONNECTION` key.");
+});


### PR DESCRIPTION
Laravel 11 will change the default collations for MySQL 8 and MariaDB including a new database configuration entry for MariaDB (see https://github.com/laravel/framework/pull/48455)

MySQL 8: `utf8mb4_0900_ai_ci` (not supported by MariaDB and MySQL 5.7)
MariaDB: `utf8mb4_uca1400_ai_ci` (not supported by MySQL 8 and MySQL 5.7)

This PR informs Developers of this change so that they can mitigate the issue themself.