### PR TITLE
Fix: HtmlDumper::$dumpHeader is not compatible with symfony's $dumpHeader

### DIFF
--- a/src/Recorders/DumpRecorder/HtmlDumper.php
+++ b/src/Recorders/DumpRecorder/HtmlDumper.php
@@ -8,7 +8,7 @@ use Symfony\Component\VarDumper\Dumper\HtmlDumper as BaseHtmlDumper;
 
 class HtmlDumper extends BaseHtmlDumper
 {
-    protected $dumpHeader = '';
+    protected ?string $dumpHeader = '';
 
     public function dumpVariable($variable): string
     {


### PR DESCRIPTION
Fixes #175 

Happens to me while playing with Laravel 11.x
