### PR TITLE
[2.x] Fixes dump header on different symfony versions

### DIFF
--- a/src/Recorders/DumpRecorder/HtmlDumper.php
+++ b/src/Recorders/DumpRecorder/HtmlDumper.php
@@ -8,7 +8,12 @@ use Symfony\Component\VarDumper\Dumper\HtmlDumper as BaseHtmlDumper;
 
 class HtmlDumper extends BaseHtmlDumper
 {
-    protected $dumpHeader = '';
+    public function __construct($output = null, string $charset = null, int $flags = 0)
+    {
+        parent::__construct($output, $charset, $flags);
+
+        $this->setDumpHeader('');
+    }
 
     public function dumpVariable($variable): string
     {

--- a/tests/Recorders/DumpRecorder/HtmlDumperTest.php
+++ b/tests/Recorders/DumpRecorder/HtmlDumperTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use Spatie\LaravelIgnition\Recorders\DumpRecorder\HtmlDumper;
+
+it('has an empty string as dump header', function () {
+    $dumpHeader = (fn () => $this->getDumpHeader())->call(new HtmlDumper);
+
+    expect($dumpHeader)->toBe('');
+});


### PR DESCRIPTION
This pull request addresses the issue in https://github.com/spatie/laravel-ignition/issues/175. The solution involves setting the dump header property to an empty string without utilizing a property. In Symfony 7, this property is typed, whereas in Symfony 6, it is not.

Ideally, this should be tagged as hot-fix.