### PR TITLE
flare() helper method

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Spatie\FlareClient\Flare;
 use Spatie\LaravelIgnition\Renderers\ErrorPageRenderer;
 
 if (! function_exists('ddd')) {
@@ -20,5 +21,19 @@ if (! function_exists('ddd')) {
         $renderer->render($exception);
 
         die();
+    }
+}
+
+if (! function_exists('flare')) {
+    function flare(Throwable $e, array $context = []): void
+    {
+        /** @var Flare $flare */
+        $flare = app(Flare::class);
+
+        foreach ($context as $key => $value) {
+            $flare->context($key, $value);
+        }
+
+        $flare->report($e);
     }
 }


### PR DESCRIPTION
Right now, if I handle an exception, there is no particularly easy way to still pass that to Flare. Sometimes, I want to gracefully handle an error but still let Flare know that something went wrong, and give some context to the error.

This simple helper method allows Flare to be notified while continuing the execution of the script. Example usage below...

```php
try {
    throw new Exception('This shouldnt have happened');
} catch (Exception $e) {

    // gracefully continue but let Flare know
    flare($e, ['process' => 'user registration']);

    return [
      'success' => false,
      'message' => 'Sorry, unable to register you right now...'
    ];
}
```
