### PR TITLE
Feature/flare helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -27,6 +27,10 @@ if (! function_exists('ddd')) {
 if (! function_exists('flare')) {
     function flare(Throwable $e, array $context = []): void
     {
+        if (!config('flare.key')) {
+            return;
+        }
+
         /** @var Flare $flare */
         $flare = app(Flare::class);
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Spatie\FlareClient\Flare;
 use Spatie\LaravelIgnition\Renderers\ErrorPageRenderer;
 
 if (! function_exists('ddd')) {
@@ -20,5 +21,19 @@ if (! function_exists('ddd')) {
         $renderer->render($exception);
 
         die();
+    }
+}
+
+if (! function_exists('flare')) {
+    function flare(Throwable $e, array $context = []): void
+    {
+        /** @var Flare $flare */
+        $flare = app(Flare::class);
+
+        foreach ($context as $key => $value) {
+            $flare->context($key, $value);
+        }
+
+        $flare->report($e);
     }
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,5 +1,38 @@
 <?php
 
+use Mockery\MockInterface;
+use Spatie\FlareClient\Flare;
+
 it('has a ddd function', function () {
     expect(function_exists('ddd'))->toBeTrue();
 });
+
+it('has a flare function', function () {
+    expect(function_exists('flare'))->toBeTrue();
+});
+
+it('can execute the flare helper when a flare key is present', function () {
+    config()->set('flare.key', 'some-key');
+
+    $this->mock(Flare::class, function (MockInterface $mock) {
+        $mock
+            ->shouldReceive('context')->once()->with('testing', true)
+            ->shouldReceive('report')->once()->with(new Exception('This is an exception'));
+    });
+
+    flare(new Exception('This is an exception'), [
+        'testing' => true,
+    ]);
+});
+
+it('will ignore the flare helper when a flare key is not present', function () {
+
+    config()->set('flare.key', null);
+
+    app()->bind(Flare::class, function () {
+        return throw new Exception('This should not be called');
+    });
+
+    flare(new Exception('This is an exception'));
+
+})->throwsNoExceptions();


### PR DESCRIPTION
Right now, if I handle an exception, there is no particularly easy way to still pass that to Flare. Sometimes, I want to gracefully handle an error but still let Flare know that something went wrong, and give some context to the error.

This simple helper method allows Flare to be notified while continuing the execution of the script. Example usage below...

```php
try {
    throw new Exception('This shouldnt have happened');
} catch (Exception $e) {

    // gracefully continue but let Flare know
    flare($e, ['process' => 'user registration']);

    return [
      'success' => false,
      'message' => 'Sorry, unable to register you right now...'
    ];
}
```