### PR TITLE
fix: move string check/decode for data in payload

### DIFF
--- a/src/Recorders/JobRecorder/JobRecorder.php
+++ b/src/Recorders/JobRecorder/JobRecorder.php
@@ -72,13 +72,13 @@ class JobRecorder
         foreach ($payload as $key => $value) {
             if (! in_array($key, ['job', 'data', 'displayName'])) {
                 $properties[$key] = $value;
+            }
+        }
 
-                if (is_string($payload['data'])) {
-                    try {
-                        $properties['data'] = json_decode($payload['data'], true, 512, JSON_THROW_ON_ERROR);
-                    } catch (Exception $exception) {
-                    }
-                }
+        if (is_string($payload['data'])) {
+            try {
+                $properties['data'] = json_decode($payload['data'], true, 512, JSON_THROW_ON_ERROR);
+            } catch (Exception $exception) {
             }
         }
 


### PR DESCRIPTION
Back towards the end of last year, we reported an issue we were having with the JobRecorder to Flare support. We were experiencing an issue where it seemed that the `data` payload in our jobs were a string rather than an array.

At the time, [this fix](https://github.com/spatie/laravel-ignition/commit/2f30b612840f48a53189bda8c443d210ca3daa83) was applied to help us with that.

Whilst it seemed to fix the issue at the time, we've seen this issue return:

> Cannot access offset of type string on string {"exception":"[object] (TypeError(code: 0): Cannot access offset of type string on string at /home/app/vendor/spatie/laravel-ignition/src/Recorders/JobRecorder/JobRecorder.php:91)

The fix that was applied was inside the foreach loop and would only apply when there was a key in the payload that wasn't being ignored. Evidently, there are times when the payload does not contain any additional keys and so the fix is never applied.

I believe it would make more sense for this to exist outside of the foreach loop so that its always applied whenever the `$payload['data']` is a string.