### PR TITLE
Remove Reflection*::setAccessible() usage

### DIFF
--- a/src/Recorders/DumpRecorder/DumpRecorder.php
+++ b/src/Recorders/DumpRecorder/DumpRecorder.php
@@ -90,13 +90,11 @@ class DumpRecorder
     protected function ensureOriginalHandlerExists(): void
     {
         $reflectionProperty = new ReflectionProperty(VarDumper::class, 'handler');
-        $reflectionProperty->setAccessible(true);
         $handler = $reflectionProperty->getValue();
 
         if (! $handler) {
             // No handler registered yet, so we'll force VarDumper to create one.
             $reflectionMethod = new ReflectionMethod(VarDumper::class, 'register');
-            $reflectionMethod->setAccessible(true);
             $reflectionMethod->invoke(null);
         }
     }

--- a/src/Recorders/JobRecorder/JobRecorder.php
+++ b/src/Recorders/JobRecorder/JobRecorder.php
@@ -120,8 +120,6 @@ class JobRecorder
             })
             ->mapWithKeys(function (ReflectionProperty $property) use ($command) {
                 try {
-                    $property->setAccessible(true);
-
                     return [$property->name => $property->getValue($command)];
                 } catch (Error $error) {
                     return [$property->name => 'uninitialized'];

--- a/src/Views/ViewExceptionMapper.php
+++ b/src/Views/ViewExceptionMapper.php
@@ -104,7 +104,6 @@ class ViewExceptionMapper
             ->toArray();
 
         $traceProperty = new ReflectionProperty('Exception', 'trace');
-        $traceProperty->setAccessible(true);
         $traceProperty->setValue($exception, $trace);
     }
 
@@ -136,14 +135,11 @@ class ViewExceptionMapper
 
         if (! $compilerEngineReflection->hasProperty('lastCompiled') && $compilerEngineReflection->hasProperty('engine')) {
             $compilerEngine = $compilerEngineReflection->getProperty('engine');
-            $compilerEngine->setAccessible(true);
             $compilerEngine = $compilerEngine->getValue($this->compilerEngine);
             $lastCompiled = new ReflectionProperty($compilerEngine, 'lastCompiled');
-            $lastCompiled->setAccessible(true);
             $lastCompiled = $lastCompiled->getValue($compilerEngine);
         } else {
             $lastCompiled = $compilerEngineReflection->getProperty('lastCompiled');
-            $lastCompiled->setAccessible(true);
             $lastCompiled = $lastCompiled->getValue($this->compilerEngine);
         }
 


### PR DESCRIPTION
> Note: As of PHP 8.1.0, calling this method has no effect; all properties are accessible by default. 

https://www.php.net/manual/en/reflectionproperty.setaccessible.php
https://www.php.net/manual/en/reflectionmethod.setaccessible.php

PHP 8.0 support was dropped a while ago
https://github.com/spatie/laravel-ignition/commit/d9d4101ab794010e50eb7004c430e65130c8e765

This will eventually raise a deprecation notice